### PR TITLE
Taunts Refactor

### DIFF
--- a/character.lua
+++ b/character.lua
@@ -641,6 +641,7 @@ function Character.playTauntUpSfx(self, tauntUp)
     for _, t in ipairs(self.sounds.taunt_up) do
       stopIfPlaying(t)
     end
+    -- self might be a replacement character with less taunts than the selected one so confirm the index first
     if self.sounds.taunt_up[tauntUp] then
       self.sounds.taunt_up[tauntUp]:play()
     else
@@ -649,17 +650,26 @@ function Character.playTauntUpSfx(self, tauntUp)
   end
 end
 
--- tauntDown is rolled externally in order to send the exact same taunt index to the enemy as plays locally
 function Character.playTauntDownSfx(self, tauntDown)
   if #self.sounds.taunt_down ~= 0 then
     for _, t in ipairs(self.sounds.taunt_down) do
       stopIfPlaying(t)
     end
+    -- self might be a replacement character with less taunts than the selected one so confirm the index first
     if self.sounds.taunt_down[tauntDown] then
       self.sounds.taunt_down[tauntDown]:play()
     else
       playRandomSfx(self.sounds.taunt_down)
     end
+  end
+end
+
+function Character.playTaunt(self, tauntType, index)
+  -- find instead of equals for forward compatibility
+  if string.find(tauntType, "up", nil, true) then
+    self:playTauntUpSfx(index)
+  elseif string.find(tauntType, "down", nil, true) then
+    self:playTauntDownSfx(index)
   end
 end
 

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -1323,25 +1323,20 @@ function main_net_vs()
   
   local function update()
     local function handleTaunt()
+      local function getCharacter(playerNumber)
+        if P1.player_number == playerNumber then
+          return characters[P1.character]
+        elseif P2.player_number == playerNumber then
+          return characters[P2.character]
+        end
+      end
+
       local messages = server_queue:pop_all_with("taunt")
       for _, msg in ipairs(messages) do
         if msg.taunt then -- receive taunts
-          local taunts = nil
-          -- P1.character and P2.character are supposed to be already filtered with current mods, taunts may differ though!
-          if msg.player_number == select_screen.my_player_number then
-            taunts = characters[P1.character].sounds[msg.type]
-          elseif msg.player_number == select_screen.op_player_number then
-            taunts = characters[P2.character].sounds[msg.type]
-          end
-          if taunts then
-            for _, t in ipairs(taunts) do
-              t:stop()
-            end
-            if msg.index <= #taunts then
-              taunts[msg.index]:play()
-            elseif #taunts ~= 0 then
-              taunts[math.random(#taunts)]:play()
-            end
+          local character = getCharacter(msg.player_number)
+          if character ~= nil then
+            character:playTaunt(msg.type, msg.index)
           end
        end
       end

--- a/network.lua
+++ b/network.lua
@@ -312,12 +312,12 @@ function Stack.handle_input_taunt(self)
   if player_taunt_up(self.which) and self:can_taunt() and #characters[self.character].sounds.taunt_up > 0 then
     self.taunt_up = math.random(#characters[self.character].sounds.taunt_up)
     if TCP_sock then
-      json_send({taunt = true, type = "taunt_up", index = self.taunt_up})
+      json_send({taunt = true, type = "taunt_ups", index = self.taunt_up})
     end
   elseif player_taunt_down(self.which) and self:can_taunt() and #characters[self.character].sounds.taunt_down > 0 then
     self.taunt_down = math.random(#characters[self.character].sounds.taunt_down)
     if TCP_sock then
-      json_send({taunt = true, type = "taunt_down", index = self.taunt_down})
+      json_send({taunt = true, type = "taunt_downs", index = self.taunt_down})
     end
   end
 end


### PR DESCRIPTION
Removes the strong coupling of the `type` field of the message with the `character.sounds` table names.
Rather than directly accessing taunts in mainloop, character.lua now has a method to receive the taunt type + index and will do the correct thing by itself.

To ensure stable compatibility for now, the contents of the `type` messages have been renamed to the plural version so that stable can understand them and play taunts as well.
The type handler in character.lua is very generous with its matching so that we can rename the message types from "taunt_ups" and "taunt_downs" to either "taunt_up"/"taunt_down" or just "up"/"down" in the future while maintaining taunt functionality in cross client matches.